### PR TITLE
✨ [FEAT] CreateMain -> CreateEdit 이미지 전달

### DIFF
--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/SB/CreateEditSB.storyboard
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/SB/CreateEditSB.storyboard
@@ -15,7 +15,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="du6-si-s3h">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="du6-si-s3h">
                                 <rect key="frame" x="0.0" y="44" width="375" height="734"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Ia-Og-lXu">
@@ -121,6 +121,7 @@
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="gCy-0G-4qG" secondAttribute="bottom" constant="26" id="AYh-hS-aFx"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="FKX-OG-eRn" secondAttribute="trailing" constant="18" id="DcI-lq-Zq3"/>
@@ -139,7 +140,7 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="selectedImgView" destination="du6-si-s3h" id="8NX-8z-59X"/>
+                        <outlet property="selectedImgView" destination="du6-si-s3h" id="2X3-E8-RhM"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/VC/CreateEditVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/VC/CreateEditVC.swift
@@ -12,6 +12,9 @@ class CreateEditVC: BaseVC {
     // MARK: IBOutlet
     @IBOutlet weak var selectedImgView: UIImageView!
     
+    // MARK: Properties
+    var selectedImg = UIImage()
+    
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -31,7 +34,6 @@ class CreateEditVC: BaseVC {
 // MARK: - Custom Methods
 extension CreateEditVC {
     private func setImg() {
-        // TODO: 받아온 이미지로 적용
-        selectedImgView.image = UIImage(named: "image")
+        selectedImgView.image = selectedImg
     }
 }

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/VC/CreateEditVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/VC/CreateEditVC.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class CreateEditVC: BaseVC {
-
+    
     // MARK: IBOutlet
     @IBOutlet weak var selectedImgView: UIImageView!
     
@@ -20,7 +20,7 @@ class CreateEditVC: BaseVC {
         super.viewDidLoad()
         setImg()
     }
-
+    
     // MARK: IBAction
     @IBAction func tapCloseBtn(_ sender: Any) {
         self.dismiss(animated: true)
@@ -35,5 +35,9 @@ class CreateEditVC: BaseVC {
 extension CreateEditVC {
     private func setImg() {
         selectedImgView.image = selectedImg
+    }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
     }
 }

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/VC/CreateEditVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/VC/CreateEditVC.swift
@@ -23,7 +23,7 @@ class CreateEditVC: BaseVC {
 
     // MARK: IBAction
     @IBAction func tapCloseBtn(_ sender: Any) {
-        dismiss(animated: true)
+        self.dismiss(animated: true)
     }
     
     @IBAction func tapNextBtn(_ sender: Any) {

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateMain/VC/CreateMainVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateMain/VC/CreateMainVC.swift
@@ -121,9 +121,14 @@ extension CreateMainVC: UICollectionViewDelegateFlowLayout {
 extension CreateMainVC : UIImagePickerControllerDelegate, UINavigationControllerDelegate{
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         
+        guard let createEditVC = UIStoryboard.init(name: Identifiers.CreateEditSB, bundle: nil).instantiateViewController(withIdentifier: CreateEditVC.className) as? CreateEditVC else { return }
+        
         if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage{
-            //TODO: 다음 VC에서 이미지 띄워주기
+            createEditVC.selectedImg = image
         }
-        dismiss(animated: true)
+        dismiss(animated: false) {
+            createEditVC.modalPresentationStyle = .fullScreen
+            self.present(createEditVC, animated: true)
+        }
     }
 }

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateMain/VC/CreateMainVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateMain/VC/CreateMainVC.swift
@@ -126,7 +126,7 @@ extension CreateMainVC : UIImagePickerControllerDelegate, UINavigationController
         if let img = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
             createEditVC.selectedImg = img
         }
-        dismiss(animated: false) {
+        self.dismiss(animated: false) {
             createEditVC.modalPresentationStyle = .fullScreen
             self.present(createEditVC, animated: true)
         }

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateMain/VC/CreateMainVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateMain/VC/CreateMainVC.swift
@@ -123,8 +123,8 @@ extension CreateMainVC : UIImagePickerControllerDelegate, UINavigationController
         
         guard let createEditVC = UIStoryboard.init(name: Identifiers.CreateEditSB, bundle: nil).instantiateViewController(withIdentifier: CreateEditVC.className) as? CreateEditVC else { return }
         
-        if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage{
-            createEditVC.selectedImg = image
+        if let img = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+            createEditVC.selectedImg = img
         }
         dismiss(animated: false) {
             createEditVC.modalPresentationStyle = .fullScreen


### PR DESCRIPTION
## 🍎 관련 이슈
closed #9 

## 🍎 변경 사항 및 이유
- CreateMain의 imagePicker로 가져온 이미지를 CreateEdit 뷰에 전달해서 띄웠습니다.
- imagePicker 창 dismiss하면서 CreateEdit뷰 present 하였습니다.
- 상태바 글자 색상 화이트로 변경하였습니다.

## 🍎 PR Point
- 시뮬 돌려보면 fullscreen이 제대로 먹는데 녹화하면 위에 빈공간이 남아보이네요 허허

## 📸 ScreenShot
![Simulator Screen Recording - iPhone 11 - 2022-05-21 at 15 29 26](https://user-images.githubusercontent.com/58043306/169639088-28bbed70-05cc-4293-8be2-dd27410d1506.gif)