### PR TITLE
✨ [FEAT] 화면전환 플로우 연결

### DIFF
--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/SB/CreateEditSB.storyboard
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/SB/CreateEditSB.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/VC/CreateEditVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/VC/CreateEditVC.swift
@@ -22,12 +22,16 @@ class CreateEditVC: BaseVC {
     }
     
     // MARK: IBAction
-    @IBAction func tapCloseBtn(_ sender: Any) {
+    @IBAction func tapCloseBtn(_ sender: UIButton) {
         self.dismiss(animated: true)
     }
     
-    @IBAction func tapNextBtn(_ sender: Any) {
-        // TODO: 다음 VC로 이미지 전달, push로 구현
+    @IBAction func tapNextBtn(_ sender: UIButton) {
+        guard let uploadVC = UIStoryboard.init(name: Identifiers.CreateUploadSB, bundle: nil).instantiateViewController(withIdentifier: CreateUploadVC.className) as? CreateUploadVC else { return }
+        
+        uploadVC.selectedImg = selectedImgView.image ?? selectedImg
+        self.navigationController?.pushViewController(uploadVC, animated: true)
+
     }
 }
 

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/VC/CreateEditVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateEdit/VC/CreateEditVC.swift
@@ -31,7 +31,6 @@ class CreateEditVC: BaseVC {
         
         uploadVC.selectedImg = selectedImgView.image ?? selectedImg
         self.navigationController?.pushViewController(uploadVC, animated: true)
-
     }
 }
 

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateMain/VC/CreateMainVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateMain/VC/CreateMainVC.swift
@@ -121,14 +121,14 @@ extension CreateMainVC: UICollectionViewDelegateFlowLayout {
 extension CreateMainVC : UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         
-        guard let creatEditVC = UIStoryboard.init(name: Identifiers.CreateEditSB, bundle: nil).instantiateViewController(withIdentifier: CreateEditVC.className) as? CreateEditVC else { return }
+        guard let createEditVC = UIStoryboard.init(name: Identifiers.CreateEditSB, bundle: nil).instantiateViewController(withIdentifier: CreateEditVC.className) as? CreateEditVC else { return }
         
         if let img = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
-            creatEditVC.selectedImg = img
+            createEditVC.selectedImg = img
         }
         
         self.dismiss(animated: false) {
-            let creatEditNC = UINavigationController(rootViewController: creatEditVC)
+            let creatEditNC = UINavigationController(rootViewController: createEditVC)
             creatEditNC.isNavigationBarHidden = true
             creatEditNC.modalPresentationStyle = .fullScreen
             self.present(creatEditNC, animated: true)

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateMain/VC/CreateMainVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateMain/VC/CreateMainVC.swift
@@ -118,17 +118,20 @@ extension CreateMainVC: UICollectionViewDelegateFlowLayout {
 }
 
 // MARK: - UIImagePickerControllerDelegate, UINavigationControllerDelegate
-extension CreateMainVC : UIImagePickerControllerDelegate, UINavigationControllerDelegate{
+extension CreateMainVC : UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         
-        guard let createEditVC = UIStoryboard.init(name: Identifiers.CreateEditSB, bundle: nil).instantiateViewController(withIdentifier: CreateEditVC.className) as? CreateEditVC else { return }
+        guard let creatEditVC = UIStoryboard.init(name: Identifiers.CreateEditSB, bundle: nil).instantiateViewController(withIdentifier: CreateEditVC.className) as? CreateEditVC else { return }
         
         if let img = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
-            createEditVC.selectedImg = img
+            creatEditVC.selectedImg = img
         }
+        
         self.dismiss(animated: false) {
-            createEditVC.modalPresentationStyle = .fullScreen
-            self.present(createEditVC, animated: true)
+            let creatEditNC = UINavigationController(rootViewController: creatEditVC)
+            creatEditNC.isNavigationBarHidden = true
+            creatEditNC.modalPresentationStyle = .fullScreen
+            self.present(creatEditNC, animated: true)
         }
     }
 }

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateUpload/SB/CreateUploadSB.storyboard
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateUpload/SB/CreateUploadSB.storyboard
@@ -26,21 +26,26 @@
                                         <color key="textColor" name="gray900"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icLeftbutton" translatesAutoresizingMaskIntoConstraints="NO" id="rDL-Bz-xaV">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="acN-cv-PwG">
                                         <rect key="frame" x="6" y="6" width="48" height="48"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" secondItem="rDL-Bz-xaV" secondAttribute="height" multiplier="1:1" id="IPW-d6-z8k"/>
+                                            <constraint firstAttribute="width" secondItem="acN-cv-PwG" secondAttribute="height" multiplier="1:1" id="2DV-dy-xqh"/>
                                         </constraints>
-                                    </imageView>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" image="icLeftbutton"/>
+                                        <connections>
+                                            <action selector="tapBackBtn:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="kL4-T8-fc2"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="acN-cv-PwG" secondAttribute="bottom" constant="6" id="26I-7g-c6C"/>
+                                    <constraint firstItem="acN-cv-PwG" firstAttribute="leading" secondItem="DGK-NN-Vr2" secondAttribute="leading" constant="6" id="5im-JY-aIy"/>
                                     <constraint firstItem="Wn5-MB-l4o" firstAttribute="centerY" secondItem="DGK-NN-Vr2" secondAttribute="centerY" id="9y2-G1-OAJ"/>
-                                    <constraint firstItem="rDL-Bz-xaV" firstAttribute="leading" secondItem="DGK-NN-Vr2" secondAttribute="leading" constant="6" id="G5v-WY-s3u"/>
                                     <constraint firstAttribute="height" constant="60" id="Mpc-Nk-Thd"/>
-                                    <constraint firstItem="rDL-Bz-xaV" firstAttribute="top" secondItem="DGK-NN-Vr2" secondAttribute="top" constant="6" id="NmR-mP-MzV"/>
                                     <constraint firstItem="Wn5-MB-l4o" firstAttribute="centerX" secondItem="DGK-NN-Vr2" secondAttribute="centerX" id="W5w-ka-5xQ"/>
-                                    <constraint firstAttribute="bottom" secondItem="rDL-Bz-xaV" secondAttribute="bottom" constant="6" id="uos-JM-kJX"/>
+                                    <constraint firstItem="acN-cv-PwG" firstAttribute="top" secondItem="DGK-NN-Vr2" secondAttribute="top" constant="6" id="mVl-5u-Wcq"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oqm-S7-22c">
@@ -57,7 +62,7 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="skyBackground" translatesAutoresizingMaskIntoConstraints="NO" id="gzK-cT-wtS">
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="gzK-cT-wtS">
                                         <rect key="frame" x="275" y="5" width="82" height="110"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="82" id="F1C-MR-gTv"/>
@@ -347,6 +352,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="contentImgView" destination="gzK-cT-wtS" id="t2Q-14-Hrr"/>
                         <outlet property="darkBgView" destination="4BL-Uq-yXK" id="kOu-Vf-Zbb"/>
                         <outlet property="mainTextView" destination="sFs-R3-RBX" id="MbF-IK-0fi"/>
                     </connections>
@@ -358,13 +364,12 @@
     </scenes>
     <resources>
         <image name="icArrowLineRight" width="16" height="16"/>
-        <image name="icChatFill" width="20" height="20"/>
+        <image name="icChatFill" width="40.666667938232422" height="40.666667938232422"/>
         <image name="icHashLilne" width="12" height="12"/>
         <image name="icIdcardsFill" width="20" height="20"/>
         <image name="icLeftbutton" width="48" height="48"/>
         <image name="icPlanetFill" width="20" height="20"/>
         <image name="icUserFill" width="20" height="20"/>
-        <image name="skyBackground" width="800" height="1094"/>
         <namedColor name="gray100">
             <color red="0.95686274509803926" green="0.95294117647058818" blue="0.96470588235294119" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateUpload/SB/CreateUploadSB.storyboard
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateUpload/SB/CreateUploadSB.storyboard
@@ -307,14 +307,18 @@
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rQb-TK-w9n">
                                 <rect key="frame" x="18" y="702" width="339" height="56"/>
+                                <color key="backgroundColor" name="point"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="nBz-15-keh"/>
                                 </constraints>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="완료">
-                                    <fontDescription key="titleFontDescription" type="system" weight="semibold" pointSize="16"/>
-                                    <color key="baseBackgroundColor" name="point"/>
-                                </buttonConfiguration>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="완료">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <connections>
+                                    <action selector="tapCompleteBtn:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="MZT-i2-ZWS"/>
+                                </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4BL-Uq-yXK">
                                 <rect key="frame" x="0.0" y="244" width="375" height="568"/>
@@ -352,6 +356,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="completeBtn" destination="rQb-TK-w9n" id="lOF-t5-ncG"/>
                         <outlet property="contentImgView" destination="gzK-cT-wtS" id="t2Q-14-Hrr"/>
                         <outlet property="darkBgView" destination="4BL-Uq-yXK" id="kOu-Vf-Zbb"/>
                         <outlet property="mainTextView" destination="sFs-R3-RBX" id="MbF-IK-0fi"/>

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateUpload/VC/CreateUploadVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateUpload/VC/CreateUploadVC.swift
@@ -13,6 +13,7 @@ class CreateUploadVC: BaseVC {
     @IBOutlet weak var mainTextView: UITextView!
     @IBOutlet weak var darkBgView: UIView!
     @IBOutlet weak var contentImgView: UIImageView!
+    @IBOutlet weak var completeBtn: UIButton!
     
     // MARK: Properties
     var selectedImg = UIImage()
@@ -27,11 +28,18 @@ class CreateUploadVC: BaseVC {
     @IBAction func tapBackBtn(_ sender: UIButton) {
         self.navigationController?.popViewController(animated: true)
     }
+    
+    @IBAction func tapCompleteBtn(_ sender: UIButton) {
+        NotificationCenter.default.post(name: NSNotification.Name("completeBtnDidTap"), object: contentImgView.image, userInfo: nil)
+        
+        self.dismiss(animated: true, completion: nil)
+    }
 }
 
 // MARK: - UI
 extension CreateUploadVC {
     private func configUI() {
+        completeBtn.makeRounded(cornerRadius: 6.adjusted)
         mainTextView.textColor = .gray300
         darkBgView.isHidden = true
         contentImgView.makeRounded(cornerRadius: 10.adjusted)

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateUpload/VC/CreateUploadVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateUpload/VC/CreateUploadVC.swift
@@ -25,6 +25,7 @@ class CreateUploadVC: BaseVC {
         setDelegate()
     }
     
+    // MARK: IBAction
     @IBAction func tapBackBtn(_ sender: UIButton) {
         self.navigationController?.popViewController(animated: true)
     }

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateUpload/VC/CreateUploadVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/CreateUpload/VC/CreateUploadVC.swift
@@ -12,12 +12,20 @@ class CreateUploadVC: BaseVC {
     // MARK: IBOutlet
     @IBOutlet weak var mainTextView: UITextView!
     @IBOutlet weak var darkBgView: UIView!
+    @IBOutlet weak var contentImgView: UIImageView!
+    
+    // MARK: Properties
+    var selectedImg = UIImage()
     
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         configUI()
         setDelegate()
+    }
+    
+    @IBAction func tapBackBtn(_ sender: UIButton) {
+        self.navigationController?.popViewController(animated: true)
     }
 }
 
@@ -26,6 +34,8 @@ extension CreateUploadVC {
     private func configUI() {
         mainTextView.textColor = .gray300
         darkBgView.isHidden = true
+        contentImgView.makeRounded(cornerRadius: 10.adjusted)
+        contentImgView.image = selectedImg
     }
 }
 

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/Feed/SB/FeedSB.storyboard
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/Feed/SB/FeedSB.storyboard
@@ -15,8 +15,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="skyBackground" translatesAutoresizingMaskIntoConstraints="NO" id="3Cy-af-eUT">
-                                <rect key="frame" x="0.0" y="-141" width="375" height="1094"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3Cy-af-eUT">
+                                <rect key="frame" x="0.0" y="44" width="375" height="734"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VvF-TX-YpT">
                                 <rect key="frame" x="0.0" y="44" width="375" height="60"/>
@@ -199,11 +199,12 @@
                         <constraints>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="BUl-8l-uhq" secondAttribute="trailing" constant="10" id="5Ea-Zy-Vo5"/>
                             <constraint firstItem="nml-4F-OLW" firstAttribute="top" secondItem="BIz-Fm-koW" secondAttribute="bottom" constant="8" id="5tB-D8-ki0"/>
-                            <constraint firstItem="3Cy-af-eUT" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" id="8fP-uC-Pb9"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="3Cy-af-eUT" secondAttribute="bottom" id="M1W-Y5-e5S"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="I8A-LJ-yyt" secondAttribute="bottom" constant="17" id="R1A-EP-xA0"/>
                             <constraint firstItem="3Cy-af-eUT" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="RNB-Pz-m53"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="VvF-TX-YpT" secondAttribute="trailing" id="VTy-HY-9uf"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="3Cy-af-eUT" secondAttribute="trailing" id="YVP-Or-qtB"/>
+                            <constraint firstItem="3Cy-af-eUT" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="apk-XY-iwu"/>
                             <constraint firstItem="BIz-Fm-koW" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="18" id="gwY-uz-I0J"/>
                             <constraint firstItem="VvF-TX-YpT" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="haD-5W-E4h"/>
                             <constraint firstItem="VvF-TX-YpT" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="hin-uI-LVz"/>
@@ -216,6 +217,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="EMR-hj-XPt"/>
                     <connections>
+                        <outlet property="contentImgView" destination="3Cy-af-eUT" id="2Ti-Sp-idM"/>
                         <outlet property="mainContentLabel" destination="nml-4F-OLW" id="Ypy-Wf-NCU"/>
                         <outlet property="moreBtn" destination="I8A-LJ-yyt" id="jKZ-NG-Juy"/>
                         <outlet property="profileImgView" destination="NO2-CN-s0w" id="S6A-cZ-K1q"/>
@@ -251,6 +253,5 @@
         <image name="icFeedShare" width="48" height="62"/>
         <image name="icSearchLineWhite" width="36" height="36"/>
         <image name="posethumbnail9" width="163.66667175292969" height="170"/>
-        <image name="skyBackground" width="800" height="1094"/>
     </resources>
 </document>

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/Feed/VC/FeedVC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/Feed/VC/FeedVC.swift
@@ -14,11 +14,13 @@ class FeedVC: BaseVC {
     @IBOutlet weak var mainContentLabel: UILabel!
     @IBOutlet weak var profileImgView: UIImageView!
     @IBOutlet weak var moreBtn: UIButton!
+    @IBOutlet weak var contentImgView: UIImageView!
     
     // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         configUI()
+        addObserver()
         configMainTextLabelShort()
     }
     
@@ -68,6 +70,19 @@ extension FeedVC {
         let lineCount = mainContentLabel.maxNumberOfLines
         if lineCount <= 2 {
             moreBtn.isHidden = true
+        }
+    }
+}
+
+// MARK: - Custom Methods
+extension FeedVC {
+    private func addObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(setContentImg), name: NSNotification.Name("completeBtnDidTap"), object: nil)
+    }
+    
+    @objc func setContentImg(_ notification: Notification) {
+        if let receivedImg = notification.object as? UIImage {
+            self.contentImgView.image = receivedImg
         }
     }
 }

--- a/ZEPETO-iOS/ZEPETO-iOS/Screen/TabBar/VC/ZepetoTBC.swift
+++ b/ZEPETO-iOS/ZEPETO-iOS/Screen/TabBar/VC/ZepetoTBC.swift
@@ -13,6 +13,7 @@ class ZepetoTBC: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configTabBar()
+        addObserver()
     }
 }
 
@@ -52,6 +53,17 @@ extension ZepetoTBC {
         tabBar.backgroundColor = .white
         tabBar.tintColor = .gray900
         tabBar.unselectedItemTintColor = .gray900
+    }
+    
+    private func addObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(setTabBarIndex), name: NSNotification.Name("completeBtnDidTap"), object: nil)
+    }
+    
+    @objc func setTabBarIndex() {
+        self.selectedIndex = 3
+        tabBar.backgroundColor = .black
+        tabBar.tintColor = .white
+        tabBar.unselectedItemTintColor = .white
     }
 }
 


### PR DESCRIPTION
## 🍎 관련 이슈
closed #15

## 🍎 변경 사항 및 이유
- 전체 화면 전환 플로우 연결 및 데이터 전달을 모두 완료했습니다.

## 🍎 PR Point
- 자잘한 UI 수정(버튼이어야 하는데 이미지로 되어있다거나 레이아웃 잘못 잡혀있는 부분 모두 수정)
- EditVC -> UploadVC 화면전환(push 방식으로 전환 + 이미지 데이터까지 전달되어야해서 navigationController 객체를 생성하여 전환해주었습니다.)
- 게시글 업로드 완료 시 FeedTab이 보이도록 (NotificationCenter 이용한 selectedTab 분기처리 및 데이터 전달)
**+** 피드탭 이미지 전달 같은 경우에는 서버 연결 시 서버 이미지를 받아와서 보여줄 예정이라 크게 신경은 안써도 될 것 같습니다!

## 📸 ScreenShot

https://user-images.githubusercontent.com/63277563/170661380-0f7896b6-bb12-48ab-84c7-13813c8c7fcf.mp4


